### PR TITLE
Rename sim tooling directories

### DIFF
--- a/docs/plan/2025-10-06-sim-tools.md
+++ b/docs/plan/2025-10-06-sim-tools.md
@@ -1,7 +1,7 @@
 # Plan Log 2025-10-06
 - spec:sim-tools
 - branch: feature/sim-tools-requirements
-- handoff commands: `./scripts/test.sh tests/sim`
+- handoff commands: `./scripts/test.sh tests/sim-tools`
 
 ## Intent
 - Provide local automation for `Create Room` and `Join Room` behaviours so developers can iterate without multiple physical devices.
@@ -10,11 +10,11 @@
 
 ## Tasks
 1. Draft `docs/spec/sim-tools.md` describing server and client simulators plus logging expectations.
-2. Implement reusable simulator modules under `src/sim/` with deterministic loops suitable for CLI use.
+2. Implement reusable simulator modules `src/sim-tools/simulation_created_room.lua` and `src/sim-tools/simulation_join_room.lua` with deterministic loops suitable for CLI use.
 3. Expose shell wrappers `scripts/run-room-server.sh` and `scripts/run-room-client.sh` which execute the simulators using LuaJIT.
-4. Add behaviour specs mirroring the modules in `tests/sim/`, referencing `spec:sim-tools` for traceability.
+4. Add behaviour specs mirroring the modules in `tests/sim-tools/simulation_created_room_spec.lua` and `tests/sim-tools/simulation_join_room_spec.lua`, referencing `spec:sim-tools` for traceability.
 5. Update `README.md` with quick-start instructions and link CLI usage to the spec.
-6. Run `./scripts/test.sh tests/sim` to verify the new suite.
+6. Run `./scripts/test.sh tests/sim-tools` to verify the new suite.
 
 ## Coordination
 - Track day-to-day progress in `docs/tasks/2025-10-06-sim-tools.md` (spec:sim-tools).

--- a/docs/tasks/2025-10-06-sim-tools.md
+++ b/docs/tasks/2025-10-06-sim-tools.md
@@ -3,11 +3,11 @@
 - branch: feature/sim-tools-requirements
 
 ## Open Work
-1. Implement `src/sim/server.lua` and `src/sim/client.lua` harnesses that wrap existing networking modules for CLI use.
+1. Implement `src/sim-tools/simulation_created_room.lua` and `src/sim-tools/simulation_join_room.lua` harnesses that wrap existing networking modules for CLI use.
 2. Author CLI scripts `scripts/run-room-server.sh` and `scripts/run-room-client.sh` that execute the simulators with the required flags.
-3. Add behaviour specs in `tests/sim/` to cover server accept flow and client discovery/join loops using stubs.
+3. Add behaviour specs `tests/sim-tools/simulation_created_room_spec.lua` and `tests/sim-tools/simulation_join_room_spec.lua` to cover server accept flow and client discovery/join loops using stubs.
 4. Document simulator usage in `README.md` under Quickstart Networking and cross-link `spec:sim-tools`.
-5. Gate new flows with `./scripts/test.sh tests/sim` in CI notes once specs are implemented.
+5. Gate new flows with `./scripts/test.sh tests/sim-tools` in CI notes once specs are implemented.
 
 ## Notes
 - Capture log format updates in this tracker if TRACE schema changes.

--- a/src/sim-tools/simulation_created_room.lua
+++ b/src/sim-tools/simulation_created_room.lua
@@ -1,8 +1,8 @@
--- src/sim/server.lua
+-- src/sim-tools/simulation_created_room.lua
 local RoomServer = require "network.room_server"
 local Discovery = require "network.discovery"
 
-local function main()
+local function run_simulation_created_room()
     -- TODO(spec:sim-tools): Read port/room-id from CLI args instead of hard-coding values here.
     local server = RoomServer:new({
         port = 53316,
@@ -33,4 +33,4 @@ local function main()
     end
 end
 
-main()
+run_simulation_created_room()

--- a/src/sim-tools/simulation_join_room.lua
+++ b/src/sim-tools/simulation_join_room.lua
@@ -1,7 +1,7 @@
--- src/sim/client.lua
+-- src/sim-tools/simulation_join_room.lua
 local Discovery = require "network.discovery"
 
-local function main()
+local function run_simulation_join_room()
     -- TODO(spec:sim-tools): Accept broadcast/udp-port flags and configure discovery accordingly.
     local discovery = Discovery:new({
         port = 53316,
@@ -22,4 +22,4 @@ local function main()
     end
 end
 
-main()
+run_simulation_join_room()

--- a/tests/sim-tools/simulation_created_room_spec.lua
+++ b/tests/sim-tools/simulation_created_room_spec.lua
@@ -1,8 +1,8 @@
--- tests/sim/server_accept_spec.lua
+-- tests/sim-tools/simulation_created_room_spec.lua
 local busted = require "busted"
 local RoomServer = require "network.room_server"
 
-describe("Room Server Accept Flow", function()
+describe("Simulation-Created Room accepts join payloads (spec:sim-tools)", function()
     local server
 
     setup(function()

--- a/tests/sim-tools/simulation_join_room_spec.lua
+++ b/tests/sim-tools/simulation_join_room_spec.lua
@@ -1,8 +1,8 @@
--- tests/sim/client_discovery_spec.lua
+-- tests/sim-tools/simulation_join_room_spec.lua
 local busted = require "busted"
 local Discovery = require "network.discovery"
 
-describe("Client Discovery", function()
+describe("Simulation-Join Room discovers servers (spec:sim-tools)", function()
     local discovery
 
     setup(function()


### PR DESCRIPTION
## Summary
- rename the simulator module directory to `src/sim-tools` and keep file headers in sync
- rename the simulator spec directory to `tests/sim-tools` and adjust file metadata
- update sim-tools plan, spec, and task docs to reference the new directory names and test commands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db225b9c508324a27e88e45011d5bd