### PR TITLE
Align sim-tools docs with CLI isolation guardrails

### DIFF
--- a/docs/plan/2025-10-06-sim-tools.md
+++ b/docs/plan/2025-10-06-sim-tools.md
@@ -6,7 +6,13 @@
 ## Intent
 - Provide local automation for `Create Room` and `Join Room` behaviours so developers can iterate without multiple physical devices.
 - Build lightweight simulators that reuse `src/network` modules to avoid drift from runtime logic.
-- Capture CLI entrypoints under `scripts/` for downstream agents to drive from CI or remote shells.
+- Capture CLI entrypoints under `scripts/` for downstream agents to drive from CI or remote shells while leaving runtime-facing collections untouched.
+
+## Requirements Alignment (spec:sim-tools)
+- Server simulator: drive the existing networking stack (`RoomServer`, `Discovery`) from an isolated CLI entrypoint without modifying `main` collections or HUD flows.
+- Client simulator: reuse runtime protocol constants via CLI-only harnesses that never touch gameplay UI.
+- Logging: provide structured TRACE events for automation and manual runs without depending on HUD mirroring.
+- Scope guardrails: confine new automation to `src/sim-tools/`, `scripts/sim-tools/`, `tests/sim-tools/`, and docs; avoid changes under `main/` unless future specs require it.
 
 ## Tasks
 1. Draft `docs/spec/sim-tools.md` describing server and client simulators plus logging expectations.
@@ -15,6 +21,93 @@
 4. Add behaviour specs mirroring the modules in `tests/sim-tools/simulation_created_room_spec.lua` and `tests/sim-tools/simulation_join_room_spec.lua`, referencing `spec:sim-tools` for traceability.
 5. Update `README.md` with quick-start instructions and link CLI usage to the spec.
 6. Run `./scripts/test.sh tests/sim-tools` to verify the new suite.
+7. Capture quick validation snippets (`./scripts/run-room-server.sh --duration 3`, `./scripts/run-room-client.sh --duration 3`) inside docs/tasks so shell execution remains the canonical smoke test.
+
+## Sub-requirements Breakdown
+- **Simulator Harness Foundations**
+  - Stabilise the shared networking primitives (`RoomServer`, `Discovery`) needed by both harnesses and surface deterministic configuration inputs (`--port`, `--room-id`, `--duration`, `--udp-port`, `--broadcast`).
+  - Ensure lifecycle management covers startup, happy-path operation, and graceful shutdown (SIGINT) for each simulator while staying aligned with the runtime flows documented in the spec scenarios.
+- **CLI Entry Points**
+  - Define dedicated scripts under `scripts/sim-tools/` that translate CLI flags into harness parameters and propagate exit codes plus TRACE logs required by automation.
+  - Provide developer-friendly wrappers (`scripts/run-room-server.sh`, `scripts/run-room-client.sh`) that can boot the simulators directly or via headless Bob builds without depending on GUI collections.
+- **Logging & Observability**
+  - Emit the structured log families (`TRACE|sim.server|…`, `TRACE|sim.client|…`, `TRACE|sim-tools|…`) so downstream agents can assert behaviour without needing HUD hooks.
+  - Provide CLI-facing sinks (stdout/jsonl) that remain fully contained in `src/sim-tools/`.
+- **Runtime ↔ Simulator Isolation**
+  - Keep simulator code paths out of `main/` collections and HUD scripts; simulators operate strictly through CLI entrypoints.
+  - Capture terminology guidance inside docs/spec and CLI help text instead of touching runtime UI labels reserved for the shipped experience.
+- **Test Coverage & Automation Hooks**
+  - Expand `tests/sim-tools/` specs to cover server accept loops, client discovery/join flows, and CLI duration/exit semantics described under Scenarios S1–S3.
+  - Document automation expectations (duration caps, non-zero failures, log assertions) so CI agents can orchestrate self-tests without manual intervention.
+
+## Implementation Breakdown by Artifact
+### Simulator Harness Foundations ↔ Existing Code
+- `src/network/room_server.lua`
+  - Reuse `RoomServer:new`, `RoomServer:start`, and `RoomServer:update` as the authoritative TCP lifecycle for the Simulation-Created Room flow; expose `RoomServer:set_on_join` in harness builders instead of reaching into `RoomServer.players` or `clients` directly.
+  - Extend `respond` to emit structured logs by funnelling events through the upcoming `sim_tools_log.trace(component, action, status, fields)` helper so server joins can be asserted without scraping `print` output.
+- `src/network/discovery.lua`
+  - Continue to lean on `Discovery:new`, `Discovery:listen`, `Discovery:broadcast_hello`, and `Discovery:receive` to satisfy discovery requirements for both simulators.
+  - Surface deterministic broadcast configuration by letting the harness wrap `Discovery:set_on_hello` and `Discovery:close` and by threading CLI-derived overrides into `Discovery:new`.
+- `src/sim-tools/simulation_created_room.lua`
+  - Refactor the `run_simulation_created_room()` entry point to delegate to a new `build_server_harness(config)` constructor that wires a `RoomServer` instance, `Discovery` listener, and scheduler loop while honouring `--port`, `--room-id`, and `--duration` flags.
+  - Swap the bare `while true` loop for a reusable `run_until_done(loop_state)` helper that exits on duration expiry or SIGINT, using `socket.sleep` cadence sourced from config.
+- `src/sim-tools/simulation_join_room.lua`
+  - Mirror the server harness changes by calling `build_client_harness(config)` so the Simulation-Join Room flow can reuse the same scheduler loop and respect `--broadcast`, `--udp-port`, and `--duration`.
+  - Promote the TODO around TCP join attempts into a dedicated `attempt_room_join(discovery_event, opts)` function that reuses `RoomServer` protocol constants and logs `TRACE|sim.client|join|…` outcomes.
+- **New artifacts for review**
+  - `src/sim-tools/harness/server.lua` exporting `build_server_harness(config, deps)` and `run_server_loop(harness_state)`.
+  - `src/sim-tools/harness/client.lua` exporting `build_client_harness(config, deps)` and `run_client_loop(harness_state)`.
+  - `src/sim-tools/logging.lua` exporting `trace(component, action, status, fields)` so both harnesses share structured logging semantics.
+
+### CLI Entry Points ↔ Existing Code
+- `scripts/sim-tools/simulation-created-room.sh` & `scripts/sim-tools/simulation-join-room.sh`
+  - Replace placeholder `echo` lines with invocations of `lua src/sim-tools/cli.lua simulation-created-room …` / `simulation-join-room …`, keeping the current TRACE comment headers so automation can detect pending vs. ready states.
+  - Capture exit codes from the Lua harness and forward them to the shell so CI agents can act on failures.
+- `scripts/test.sh` and `scripts/test-network.sh`
+  - Keep these wrappers intact but document that `./scripts/test.sh tests/sim-tools` now exercises CLI parsing via stubbed argv arrays.
+- **New artifacts for review**
+  - `src/sim-tools/cli.lua` exposing `parse_argv(argv)` and `dispatch(command, argv, deps)` to bridge shell scripts with harness modules.
+  - `scripts/run-room-server.sh` invoking the CLI helper with sane defaults (`--port`, `--room-id`, `--duration`).
+  - `scripts/run-room-client.sh` mirroring the server wrapper while passing `--broadcast`, `--udp-port`, and `--duration`.
+  - `input/sim-tools/example-room-server.args` capturing a sample argv manifest for documentation and smoke tests.
+
+### Logging & Observability ↔ Existing Code
+- `src/sim-tools/logging.lua`
+  - Provide a shared helper (`trace(component, action, status, fields)`) that emits structured logs without coupling to runtime HUD state.
+- `src/sim-tools/harness/*`
+  - Accept optional sink callbacks (e.g. write-to-file, stdout collector) to keep simulator output configurable while remaining independent from `main` scene objects.
+- **New artifacts for review**
+  - `src/sim-tools/log_sinks.lua` defining CLI-focused sinks (stdout, jsonl file) that can be toggled per harness.
+  - `tests/sim-tools/sim_tools_logging_spec.lua` asserting TRACE events are captured through these sinks without invoking UI helpers.
+
+### Runtime ↔ Simulator Isolation Plan
+- `main/` collections & scripts
+  - Leave untouched; the existing HUD and button flows remain reserved for the actual game experience.
+- `src/sim-tools/ui/` (optional future scope)
+  - If lightweight simulator status displays are required later, place them under a new namespace to keep parity with the CLI while avoiding reuse of `main/ui` resources.
+- Documentation touchpoints
+  - Clarify in `docs/spec/sim-tools.md` and README simulator sections that the tooling operates headlessly/CLI-first and does not adjust game UI assets.
+- **New artifacts for review**
+  - `docs/tasks/2025-10-06-sim-tools.md` checklist entries to verify no runtime UI files change during simulator work.
+
+### Test Coverage & Automation Hooks ↔ Existing Code
+- `tests/sim-tools/simulation_created_room_spec.lua`
+  - Replace real socket calls with faked transports provided by a new `tests/support/sim_tools_fakes.lua` module so tests can assert `TRACE|sim.server|…` payloads emitted by `run_server_loop`.
+  - Add coverage for duration shutdown by simulating SIGINT via a fake `sys.get_exit_requested` dependency.
+- `tests/sim-tools/simulation_join_room_spec.lua`
+  - Verify that CLI parsing surfaces expected defaults and that discovery retries obey the harness scheduler cadence by injecting fake timers.
+- `tests/support/network_context.lua`
+  - Extend existing helpers to bootstrap server/client harnesses for specs without duplicating setup logic.
+- **New artifacts for review**
+  - `tests/support/sim_tools_fakes.lua` exposing `build_fake_socket()`, `build_fake_timer()`, and `collect_trace_logs()` utilities.
+  - `tests/sim-tools/simulation_cli_spec.lua` covering happy-path and error-path CLI usage for both simulators.
+  - `docs/plan/checklists/sim-tools-validation.md` enumerating automation expectations (duration caps, exit codes, TRACE assertions) referenced by future CI notes.
+
+## Spec / Plan / Task Audit (2025-10-06)
+- **Spec alignment**: `docs/spec/sim-tools.md` now enforces CLI-only isolation for simulators and removes any requirement to rename HUD buttons under `main/ui`. Future edits must preserve the no-UI-touch rule and keep terminology scoped to docs/CLI strings.
+- **Plan coverage**: The task list above lacks explicit smoke checks. Added Task 7 to ensure `scripts/run-room-*.sh --duration` invocations are documented as the fast shell validation path.
+- **Task tracker gaps**: `docs/tasks/2025-10-06-sim-tools.md` needs per-artifact checkboxes and command snippets so reviewers can verify work quickly from a terminal. Update the tracker to reference `./scripts/test.sh tests/sim-tools/...` and the new smoke commands.
+- **Follow-up**: Once harness modules land, mirror the audit summary into the task tracker notes to keep future agents aware of the isolation guardrails.
 
 ## Coordination
 - Track day-to-day progress in `docs/tasks/2025-10-06-sim-tools.md` (spec:sim-tools).

--- a/docs/spec/sim-tools.md
+++ b/docs/spec/sim-tools.md
@@ -13,12 +13,12 @@ This spec clarifies the behaviour of the simulation tooling workflows so that de
 Give developers single-machine room workflow coverage by adding CLI-driven simulators that mirror the in-game `Create Room` (server) and `Join Room` (client) behaviours. Each simulator must reuse existing `src/network` modules to stay in lockstep with runtime logic and emit machine-readable logs for downstream automation.
 
 ## Runtime Touchpoints
-- `main/main.script` owns the room creation and join flows exposed through the in-game HUD. It reacts to GUI button events (`ACTION_CREATE_ROOM`, `ACTION_JOIN_ROOM`) by starting or tearing down the UDP server/client helpers and keeps the UI model in sync.
-- `main/ui.gui_script` exposes the Create/Join buttons and relays user input to `main/main.script`. It reads status and log buffers through `src/ui/model.lua`.
-- `src/ui/model.lua` stores peer metadata, per-state status text, and chronological logs. Simulator automation should keep using these helpers instead of writing directly to GUI nodes.
+- `main/main.script` owns the room creation and join flows exposed through the in-game HUD. These flows remain reserved for the shipping experience; simulators must not post messages into the HUD or reuse its buttons.
+- `main/ui.gui_script` exposes the Create/Join buttons and relays user input to `main/main.script`. No simulator work should rename or rebind these controls—automation interacts strictly through CLI entry points.
+- `src/ui/model.lua` stores peer metadata, per-state status text, and chronological logs for the runtime HUD. The simulators can read protocol constants from shared modules but must not mutate this UI state.
 - `src/sim-tools/simulation_created_room.lua` wraps the runtime `RoomServer` lifecycle in the `run_simulation_created_room()` harness so CLI scripts can boot the Simulation-Created Room flow without touching UI collections.
 - `src/sim-tools/simulation_join_room.lua` exposes the complementary `run_simulation_join_room()` harness that reuses `Discovery` probes for the Simulation-Join Room workflow.
-- `scripts/sim-tools/` houses CLI entry points. These scripts should evolve into wrappers that either drive a headless build (via Bob) or emit the same `TRACE|sim.*|…` lines that runtime scripts print when they transition states so downstream tooling can assert behaviour.
+- `scripts/sim-tools/` houses CLI entry points. These scripts emit `TRACE|sim.*|…` lines so downstream tooling can assert behaviour without relying on HUD mirrors.
 
 ## Spec ↔ Code Map
 - **Simulator Harnesses**: `src/sim-tools/simulation_created_room.lua` and `src/sim-tools/simulation_join_room.lua` are the single entry points for automation. Both files tag TODOs with `spec:sim-tools` so follow-up work can reference this spec when wiring CLI flags, TRACE logging, and graceful shutdown logic.
@@ -30,28 +30,28 @@ Give developers single-machine room workflow coverage by adding CLI-driven simul
 - Must let a single machine start a room lifecycle identical to the production `Create Room` flow so agents can test without an additional host.
 - Reuse `RoomServer` primitives and expose deterministic flags (`--port`, `--room-id`, `--duration`) so automation can script predictable sessions.
 - Emit lifecycle logs in the `TRACE|sim.server|action|status|key=value` format and gracefully stop on SIGINT while reporting outcomes for future enhancements.
+- Operate entirely from CLI scripts; never require HUD interactions or modifications under `main/`.
 
 ### R2: Join-room simulator (spec:sim-tools)
 - Must autodiscover a locally broadcast server, attempt a join, and issue keepalive pings so developers can validate the end-to-end handshake without another device.
 - Reuse `Discovery` probes and `RoomServer` join logic while exposing CLI flags (`--broadcast`, `--udp-port`, `--duration`) that match the server simulator's determinism guarantees.
 - Emit machine-readable logs in the `TRACE|sim.client|action|status|key=value` format and continue to run unattended so future iterations can extend behaviours (e.g., scripted latency tests).
+- Operate entirely from CLI scripts; never require HUD interactions or modifications under `main/`.
 
-## Terminology Updates
-- Rename the existing **Create Room** simulation action to **Simulation-Created Room**.
-- Rename the existing **Join Room** simulation action to **Simulation-Join Room**.
-
-These labels distinguish simulated flows from the in-game UI actions while keeping the original behaviour intact during the proof-of-concept phase. Update the following entry points when rolling out the terminology change:
-- `main/ui.gui_script` button labels for the simulator actions.
-- `main/main.script` status copy surfaced in the simulation HUD.
-- Quick-launch scripts under `scripts/sim-tools/`.
+## Terminology & Isolation Updates
+- Keep the shipping HUD labels (**Create Room**, **Join Room**) untouched; simulator naming lives in CLI help text and documentation.
+- Refer to CLI harnesses as **Simulation-Created Room** and **Simulation-Join Room** in docs, scripts, and tests to distinguish them from the HUD flows without altering UI assets.
+- Document any simulator terminology changes inside `docs/spec/` and CLI usage strings instead of modifying `main/ui.gui` resources.
 
 ## Proof-of-Concept Scope
-During the initial phase the simulation tools mirror the production Create Room / Join Room flows without requiring real player clients. Player interaction continues to happen through the existing game UI, and simulator entry points simply trigger the same state transitions (`change_state(self, STATE_CREATE)` / `change_state(self, STATE_JOIN)`) that the HUD already uses.
+During the initial phase the simulation tools mirror the production Create Room / Join Room flows without requiring real player clients. Simulator entry points operate purely from shell scripts that spawn the harness loops; no simulator work injects messages into HUD scripts or rebinds GUI nodes. Future iterations can revisit optional HUD mirrors once CLI automation is stable.
 
 ## Instrumentation & Orchestration
-- Emit lightweight console logs in `main/main.script` (e.g. `TRACE|sim-tools|simulation-created-room|ok`) when HUD-driven flows fire so developers can correlate actions while debugging without new telemetry pipelines.
+- Emit lightweight console logs in `main/main.script` (e.g. `TRACE|sim-tools|simulation-created-room|ok`) when HUD-driven flows fire so developers can correlate actions while debugging without new telemetry pipelines. These logs remain read-only touchpoints for simulators.
 - Simulator scripts emit structured lines (`TRACE|sim.server|…`, `TRACE|sim.client|…`) that capture action, status, and key metadata (`port`, `roomId`, `peer`). Keep both log families stable to support manual runs and future automation.
-- Coordinate the self-test via a simple manual multi-process setup—run the room creation action on one process and join actions on two others—to keep the proof-of-concept quick to execute.
+- Coordinate the self-test via shell scripts—run the room server harness and the join harness from terminals using the wrappers listed below. HUD interactions stay optional for manual observation only.
+  - `./scripts/run-room-server.sh --duration 5`
+  - `./scripts/run-room-client.sh --duration 5`
 
 ## Scenarios
 ### S1: Simulation-Created Room boots and accepts join payloads
@@ -74,24 +74,24 @@ During the initial phase the simulation tools mirror the production Create Room 
 
 ## Use Cases
 ### Test player join room
-1. Execute **Simulation-Created Room** via `scripts/sim-tools/simulation-created-room.sh` to create the mock room. The script should either drive a headless build or emit a `msg.post(main:/go#main, "ui_action", { action = hash("create_room") })` equivalent so the runtime calls `start_server` and prints `TRACE|sim-tools|simulation-created-room|triggered`.
-2. From the game UI (`main/ui.gui_script`), invoke **Join Room**. This fires `ACTION_JOIN_ROOM`, causing `start_client` to bind a local UDP socket and immediately send a ping via `send_ping`.
-3. Debug or troubleshoot the join-room flow via the game UI or developer tools. Expect the join panel log (backed by `UiModel.append_log`) to show an outbound `-> broadcast` line followed by inbound `pong` messages from the simulator.
+1. Execute **Simulation-Created Room** via `scripts/sim-tools/simulation-created-room.sh`. The CLI harness binds `RoomServer` and discovery listeners without touching HUD scripts, logging `TRACE|sim.server|start|ok` on success.
+2. From the game UI (`main/ui.gui_script`), invoke **Join Room** for manual validation only. This fires `ACTION_JOIN_ROOM`, causing `start_client` to bind a local UDP socket and immediately send a ping via `send_ping`.
+3. Debug or troubleshoot the join-room flow via the game UI or developer tools. Expect the join panel log (backed by `UiModel.append_log`) to show an outbound `-> broadcast` line followed by inbound `pong` messages from the simulator. No simulator code should mutate UI nodes.
 
 ### Test player create room
-1. From the game UI (`main/ui.gui_script`), execute **Create Room** to open a new room. This transitions to `STATE_CREATE`, binding the UDP server and logging `Hosting on <ip>:53317`.
-2. Run **Simulation-Join Room** via `scripts/sim-tools/simulation-join-room.sh` to emulate a player joining. The script should mirror the client path by emitting the same JSON ping payload that `send_ping` generates (`{ "type": "ping", "peer_id": … }`) so the in-game server responds with a pong.
-3. Debug or troubleshoot the create-room flow via the game UI or developer tools. Watch for inbound `ping` entries in the Create panel log and ensure the simulator captures the corresponding pong.
+1. From the game UI (`main/ui.gui_script`), execute **Create Room** to open a new room for manual checks. This transitions to `STATE_CREATE`, binding the UDP server and logging `Hosting on <ip>:53317`.
+2. Run **Simulation-Join Room** via `scripts/sim-tools/simulation-join-room.sh` to emulate a player joining. The CLI harness emits JSON ping payloads matching `send_ping` without requiring HUD callbacks.
+3. Debug or troubleshoot the create-room flow via the game UI or developer tools. Watch for inbound `ping` entries in the Create panel log while the simulator reports `TRACE|sim.client|join|accept|roomId=…`. Keep HUD assets read-only during these tests.
 
 ### Simulation tooling self-test
-1. Run **Simulation-Created Room** on one process using `scripts/sim-tools/simulation-created-room.sh`. Confirm the console logs include both the `TRACE|sim-tools|simulation-created-room|triggered` line and the `[INFO] LocalNetTest…` readiness message.
-2. Run **Simulation-Join Room** on two additional processes using `scripts/sim-tools/simulation-join-room.sh`. Each should send the JSON ping payload and wait for pong responses, printing `TRACE|sim-tools|simulation-join-room|ok` when the payload is acknowledged.
-3. Verify that all operations complete successfully, capturing outcomes in `docs/tasks/2025-09-30-sim-tools.md` and `docs/tasks/2025-10-06-sim-tools.md`. Use the per-state status text (via `UiModel.get_status`) to record whether sockets bound correctly and note any `[WARN]` lines surfaced by `main/main.script`.
+1. Run **Simulation-Created Room** on one process using `scripts/sim-tools/simulation-created-room.sh`. Confirm the console logs include both the `TRACE|sim.server|start|ok` line and the `[INFO] LocalNetTest…` readiness message.
+2. Run **Simulation-Join Room** on two additional processes using `scripts/sim-tools/simulation-join-room.sh`. Each should send the JSON ping payload and wait for pong responses, printing `TRACE|sim.client|join|accept|roomId=…` when the payload is acknowledged.
+3. Verify that all operations complete successfully, capturing outcomes in `docs/tasks/2025-09-30-sim-tools.md` and `docs/tasks/2025-10-06-sim-tools.md`. Use CLI exit codes and TRACE logs as the source of truth; HUD logging is optional for manual inspection.
 
 ## Validation Checklist
-- [ ] Simulation labels updated throughout tooling UI and documentation.
-- [ ] Simulated flows continue to mirror game UI interactions without additional player clients.
-- [ ] Lightweight `TRACE|sim-tools|…` and CLI `TRACE|sim.*|…` console entries are emitted when simulator scripts or UI buttons trigger the flows.
+- [ ] Simulator terminology appears in CLI help text and docs only; HUD labels remain unchanged.
+- [ ] Simulated flows continue to mirror game UI interactions without additional player clients while remaining HUD-isolated.
+- [ ] Lightweight `TRACE|sim-tools|…` and CLI `TRACE|sim.*|…` console entries are emitted when simulator scripts run their harness loops.
 - [ ] Developers can execute the scenarios above without manual data setup and can rely on the linked task trackers to log outcomes.
 - [ ] Future spec updates synchronise with the listed plan, task, and test documents so executor agents inherit the same expectations.
 - [ ] `src/sim-tools/` harness names and `tests/sim-tools/` spec filenames stay aligned with `docs/plan/2025-10-06-sim-tools.md` and `docs/tasks/2025-10-06-sim-tools.md` references.

--- a/docs/tasks/2025-10-06-sim-tools.md
+++ b/docs/tasks/2025-10-06-sim-tools.md
@@ -3,12 +3,25 @@
 - branch: feature/sim-tools-requirements
 
 ## Open Work
-1. Implement `src/sim-tools/simulation_created_room.lua` and `src/sim-tools/simulation_join_room.lua` harnesses that wrap existing networking modules for CLI use.
-2. Author CLI scripts `scripts/run-room-server.sh` and `scripts/run-room-client.sh` that execute the simulators with the required flags.
-3. Add behaviour specs `tests/sim-tools/simulation_created_room_spec.lua` and `tests/sim-tools/simulation_join_room_spec.lua` to cover server accept flow and client discovery/join loops using stubs.
-4. Document simulator usage in `README.md` under Quickstart Networking and cross-link `spec:sim-tools`.
-5. Gate new flows with `./scripts/test.sh tests/sim-tools` in CI notes once specs are implemented.
+- [ ] Harness implementation: `src/sim-tools/simulation_created_room.lua`, `src/sim-tools/simulation_join_room.lua`
+  - Smoke: `./scripts/run-room-server.sh --duration 3 --port 47001 --room-id 3`
+  - Smoke: `./scripts/run-room-client.sh --duration 3 --broadcast 255.255.255.255`
+- [ ] CLI surface: `scripts/run-room-server.sh`, `scripts/run-room-client.sh`, `scripts/sim-tools/simulation-*.sh`
+  - Validation: `./scripts/sim-tools/simulation-created-room.sh --help`
+  - Validation: `./scripts/sim-tools/simulation-join-room.sh --help`
+- [ ] Behaviour specs: `tests/sim-tools/simulation_created_room_spec.lua`, `tests/sim-tools/simulation_join_room_spec.lua`, `tests/sim-tools/simulation_cli_spec.lua`
+  - Test: `./scripts/test.sh tests/sim-tools/simulation_created_room_spec.lua`
+  - Test: `./scripts/test.sh tests/sim-tools/simulation_join_room_spec.lua`
+  - Test: `./scripts/test.sh tests/sim-tools/simulation_cli_spec.lua`
+- [ ] Support modules: `tests/support/sim_tools_fakes.lua`, `src/sim-tools/logging.lua`, `src/sim-tools/log_sinks.lua`
+  - Test: `./scripts/test.sh tests/sim-tools`
+- [ ] Documentation sync: update `README.md` Quickstart networking section, refresh `docs/spec/sim-tools.md` pointers, capture audit summary in Notes.
+  - Validation: `rg "spec:sim-tools" docs README.md`
+  - Validation: `rg "Simulation-Created Room" -g"*.md"`
+- [ ] CI hand-off: document `./scripts/run-room-server.sh --duration 3` and `./scripts/run-room-client.sh --duration 3` in automation notes.
+  - Validation: append commands to `docs/plan/checklists/sim-tools-validation.md`
 
 ## Notes
 - Capture log format updates in this tracker if TRACE schema changes.
 - Revisit `docs/plan/2025-10-06-sim-tools.md` after each milestone to close completed items.
+- Ensure HUD assets remain untouched; simulators validate solely through the shell commands listed above.


### PR DESCRIPTION
## Summary
- update spec:sim-tools to emphasise CLI-only simulators, retain HUD isolation, and refresh validation scenarios
- extend the 2025-10-06 plan with a spec/plan/task audit and add shell smoke command coverage to the task list
- rewrite the 2025-10-06 task tracker with checkbox items and explicit shell commands for quick validation

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68db2711b8e883248d531d620f1670d3