### PR TITLE
spec:sim-tools wrap placeholder pseudo steps in comment blocks

### DIFF
--- a/docs/plan/checklists/sim-tools-validation.md
+++ b/docs/plan/checklists/sim-tools-validation.md
@@ -1,0 +1,4 @@
+# Simulation Tools Validation Checklist (spec:sim-tools)
+- [ ] Run `./scripts/run-room-server.sh --duration 3` once the CLI bridges are live.
+- [ ] Run `./scripts/run-room-client.sh --duration 3` to mirror the join workflow.
+- [ ] Capture TRACE output samples for server and client simulators in docs/tasks updates.

--- a/input/sim-tools/example-room-server.args
+++ b/input/sim-tools/example-room-server.args
@@ -1,0 +1,5 @@
+# input/sim-tools/example-room-server.args
+# Placeholder argv manifest for Simulation-Created Room harness (spec:sim-tools).
+--port=53316
+--room-id=sample
+--duration=5

--- a/scripts/run-room-client.sh
+++ b/scripts/run-room-client.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TRACE|sim-tools|run-room-client|pending
+# Placeholder wrapper for the Simulation-Join Room CLI entrypoint (spec:sim-tools).
+set -euo pipefail
+
+echo "Simulation-Join Room wrapper placeholder (spec:sim-tools)."
+echo "Invoke scripts/sim-tools/simulation-join-room.sh once CLI wiring lands."

--- a/scripts/run-room-server.sh
+++ b/scripts/run-room-server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# TRACE|sim-tools|run-room-server|pending
+# Placeholder wrapper for the Simulation-Created Room CLI entrypoint (spec:sim-tools).
+set -euo pipefail
+
+echo "Simulation-Created Room wrapper placeholder (spec:sim-tools)."
+echo "Invoke scripts/sim-tools/simulation-created-room.sh once CLI wiring lands."

--- a/scripts/sim-tools/simulation-created-room.sh
+++ b/scripts/sim-tools/simulation-created-room.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # TRACE|sim-tools|simulation-created-room|pending
 # Placeholder entrypoint for triggering the "Simulation-Created Room" flow.
-# Replace the echo with the actual simulator command when the flow is wired.
-echo "TODO: invoke Simulation-Created Room once the simulator CLI is available."
+# Replace these echoes with the simulator command when the CLI bridge is ready.
+set -euo pipefail
 
+echo "Simulation-Created Room CLI placeholder (spec:sim-tools)."

--- a/scripts/sim-tools/simulation-join-room.sh
+++ b/scripts/sim-tools/simulation-join-room.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # TRACE|sim-tools|simulation-join-room|pending
 # Placeholder entrypoint for triggering the "Simulation-Join Room" flow.
-# Replace the echo with the actual simulator command when the flow is wired.
-echo "TODO: invoke Simulation-Join Room once the simulator CLI is available."
+# Replace these echoes with the simulator command when the CLI bridge is ready.
+set -euo pipefail
 
+echo "Simulation-Join Room CLI placeholder (spec:sim-tools)."

--- a/src/sim-tools/cli.lua
+++ b/src/sim-tools/cli.lua
@@ -1,0 +1,49 @@
+-- src/sim-tools/cli.lua
+-- Placeholder CLI bridge for spec:sim-tools simulators.
+local server_harness = require "sim-tools.harness.server"
+local client_harness = require "sim-tools.harness.client"
+local logging = require "sim-tools.logging"
+
+local M = {}
+
+function M.parse_argv(argv)
+    --[[
+    Parse CLI arguments into a command plus option table.
+    Placeholder outline:
+      * Inspect argv for the command name (argv[1]).
+      * Expand into option tables once flag parsing lands.
+    ]]
+    return {
+        command = argv and argv[1] or nil,
+        options = {},
+    }
+end
+
+function M.dispatch(command, argv, deps)
+    --[[
+    Dispatch CLI commands to the appropriate simulator harness.
+    Placeholder outline:
+      * Resolve harness dependencies for server and client flows.
+      * Forward parsed options to harness builders.
+      * Emit TRACE lines through the shared logging helper.
+    ]]
+    if command == "simulation-created-room" then
+        local harness = server_harness.build_server_harness(argv or {}, deps)
+        return {
+            harness = harness,
+            message = logging.trace("sim.server", "dispatch", "stub"),
+        }
+    elseif command == "simulation-join-room" then
+        local harness = client_harness.build_client_harness(argv or {}, deps)
+        return {
+            harness = harness,
+            message = logging.trace("sim.client", "dispatch", "stub"),
+        }
+    end
+
+    return {
+        error = logging.trace("sim.cli", "dispatch", "unknown", { command = command or "" }),
+    }
+end
+
+return M

--- a/src/sim-tools/harness/client.lua
+++ b/src/sim-tools/harness/client.lua
@@ -1,0 +1,35 @@
+-- src/sim-tools/harness/client.lua
+-- Placeholder harness scaffolding for spec:sim-tools client loops.
+local Discovery = require "network.discovery"
+local RoomServer = require "network.room_server"
+
+local M = {}
+
+function M.build_client_harness(config, deps)
+    --[[
+    Build a table describing the Simulation-Join Room harness.
+    Placeholder outline:
+      * Configure discovery probes to locate available rooms.
+      * Attempt join operations against the advertised room server.
+      * Coordinate scheduler hooks for retries and timeouts.
+    ]]
+    return {
+        config = config or {},
+        deps = deps or {},
+        discovery = nil, -- placeholder slot for Discovery:new({...}) configuration.
+        joiner = nil, -- placeholder slot for helpers driving RoomServer joins.
+    }
+end
+
+function M.run_client_loop(state)
+    --[[
+    Drive the Simulation-Join Room lifecycle until completion.
+    Placeholder outline:
+      * Broadcast discovery requests on an interval.
+      * Handle discovery responses and attempt joins.
+      * Emit TRACE logs covering attempt/response states.
+    ]]
+    return state
+end
+
+return M

--- a/src/sim-tools/harness/server.lua
+++ b/src/sim-tools/harness/server.lua
@@ -1,0 +1,35 @@
+-- src/sim-tools/harness/server.lua
+-- Placeholder harness scaffolding for spec:sim-tools server loops.
+local RoomServer = require "network.room_server"
+local Discovery = require "network.discovery"
+
+local M = {}
+
+function M.build_server_harness(config, deps)
+    --[[
+    Build a table describing the Simulation-Created Room harness.
+    Placeholder outline:
+      * Instantiate RoomServer with configuration values.
+      * Attach Discovery listeners for broadcast announcements.
+      * Prepare scheduler hooks for cooperative multitasking.
+    ]]
+    return {
+        config = config or {},
+        deps = deps or {},
+        server = nil, -- placeholder slot for RoomServer:new({...}) once implemented.
+        discovery = nil, -- placeholder slot for Discovery:new({...}) wiring.
+    }
+end
+
+function M.run_server_loop(state)
+    --[[
+    Drive the Simulation-Created Room lifecycle until completion.
+    Placeholder outline:
+      * Iterate over queued events until shutdown.
+      * Process discovery announcements and accept joins.
+      * Emit TRACE logs for each lifecycle transition.
+    ]]
+    return state
+end
+
+return M

--- a/src/sim-tools/log_sinks.lua
+++ b/src/sim-tools/log_sinks.lua
@@ -1,0 +1,37 @@
+-- src/sim-tools/log_sinks.lua
+-- Placeholder log sink helpers for spec:sim-tools simulators.
+local M = {}
+
+function M.stdout_sink()
+    --[[
+    Return a sink function that writes TRACE lines to stdout during development.
+    Placeholder outline:
+      * Accept TRACE lines and forward to print for visibility.
+      * Guard against nil entries before printing.
+    ]]
+    return function(line)
+        if line then
+            print(line)
+        end
+    end
+end
+
+function M.collector_sink()
+    --[[
+    Return a sink capturing TRACE lines for tests to inspect.
+    Placeholder outline:
+      * Maintain an internal table of entries.
+      * Provide a push method storing new TRACE lines.
+    ]]
+    local collected = {}
+    return {
+        entries = collected,
+        push = function(_, line)
+            if line then
+                table.insert(collected, line)
+            end
+        end,
+    }
+end
+
+return M

--- a/src/sim-tools/logging.lua
+++ b/src/sim-tools/logging.lua
@@ -1,0 +1,35 @@
+-- src/sim-tools/logging.lua
+-- Placeholder structured logging helper for spec:sim-tools harnesses.
+local M = {}
+
+local function serialise_fields(fields)
+    --[[
+    Prepare key=value fragments for TRACE output once the implementation lands.
+    Placeholder outline:
+      * Accept a table of fields and turn each into " key=value".
+      * Concatenate fragments preserving insertion order.
+    ]]
+    if not fields then
+        return ""
+    end
+
+    local parts = {}
+    for key, value in pairs(fields) do
+        table.insert(parts, string.format(" %s=%s", key, tostring(value)))
+    end
+    return table.concat(parts)
+end
+
+function M.trace(component, action, status, fields)
+    --[[
+    Compose a TRACE line matching the spec:sim-tools logging contract.
+    Placeholder outline:
+      * Normalise arguments to safe defaults.
+      * Concatenate into TRACE|component|action|status format.
+      * Append serialised fields when present.
+    ]]
+    local base = string.format("TRACE|%s|%s|%s", component or "sim.tools", action or "pending", status or "stub")
+    return base .. serialise_fields(fields)
+end
+
+return M

--- a/tests/sim-tools/simulation_cli_spec.lua
+++ b/tests/sim-tools/simulation_cli_spec.lua
@@ -1,0 +1,16 @@
+-- tests/sim-tools/simulation_cli_spec.lua
+local cli = require "sim-tools.cli"
+
+describe("Simulation CLI scaffolding (spec:sim-tools)", function()
+    it("returns a stub harness when dispatching the server command", function()
+        local result = cli.dispatch("simulation-created-room", {}, {})
+        assert.is_table(result)
+        assert.is_table(result.harness)
+    end)
+
+    it("returns an error payload for unknown commands", function()
+        local result = cli.dispatch("unknown-command", {}, {})
+        assert.is_table(result)
+        assert.is_string(result.error)
+    end)
+end)

--- a/tests/support/sim_tools_fakes.lua
+++ b/tests/support/sim_tools_fakes.lua
@@ -1,0 +1,50 @@
+-- tests/support/sim_tools_fakes.lua
+-- Placeholder fakes for spec:sim-tools simulator specs.
+local M = {}
+
+function M.build_fake_socket()
+    --[[
+    Return a minimal fake socket capturing payloads for future assertions.
+    Placeholder outline:
+      * Capture payloads pushed through send for later inspection.
+      * Expand into richer fake sockets once networking hooks land.
+    ]]
+    local fake = { sent = {} }
+    function fake:send(payload)
+        table.insert(self.sent, payload)
+    end
+    return fake
+end
+
+function M.build_fake_timer()
+    --[[
+    Provide a stub timer interface consumed by harness loops later on.
+    Placeholder outline:
+      * Track elapsed time as ticks are invoked.
+      * Offer helpers for advancing time deterministically.
+    ]]
+    return {
+        elapsed = 0,
+        tick = function(self, delta)
+            self.elapsed = self.elapsed + (delta or 0)
+        end,
+    }
+end
+
+function M.collect_trace_logs()
+    --[[
+    Capture TRACE lines pushed by log sinks during specs.
+    Placeholder outline:
+      * Store each TRACE entry for assertions.
+      * Expose both the list and sink function to specs.
+    ]]
+    local lines = {}
+    return {
+        lines = lines,
+        sink = function(_, line)
+            table.insert(lines, line)
+        end,
+    }
+end
+
+return M


### PR DESCRIPTION
## Summary
- wrap each simulator placeholder outline in Lua block comments so pseudo-code remains within comment sections
- document high-level placeholder steps for CLI, harnesses, logging, and fakes without altering stub behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2ead78248324a4bed1c96512c8ab