### PR TITLE
docs:sim-tools reset scaffolding to documentation checklist

### DIFF
--- a/docs/plan/checklists/sim-tools-validation.md
+++ b/docs/plan/checklists/sim-tools-validation.md
@@ -1,0 +1,31 @@
+# Simulation Tools Validation Checklist (spec:sim-tools)
+
+The previous scaffolding attempt introduced code placeholders before the supporting plans were finalised. This checklist captures
+what still needs to exist **in documentation first** so future agents can recreate the missing files with comment-only pseudo-code
+and avoid shipping premature implementations.
+
+## Pending Artifact Layout
+- `src/sim-tools/cli.lua` & `src/sim-tools/harness/`: establish module skeletons with comment-only pseudo-code for parsing,
+  dispatch, and scheduler helpers before adding executable logic.
+- `src/sim-tools/logging.lua` & `src/sim-tools/log_sinks.lua`: outline logging intent (TRACE families, sink strategy) purely in
+  comments so later work can wire structured logging without guessing naming.
+- `tests/sim-tools/simulation_cli_spec.lua` & `tests/support/sim_tools_fakes.lua`: describe the intended test surfaces and fake
+  helpers that will exercise CLI parsing and harness loops once the code lands.
+
+## Shell Entrypoint Expectations
+- Restore wrapper scripts `scripts/run-room-server.sh` and `scripts/run-room-client.sh` as documented placeholders that call into
+  the CLI module once it exists.
+- Keep `scripts/sim-tools/simulation-created-room.sh` and `scripts/sim-tools/simulation-join-room.sh` as echo-only stubs until the
+  CLI bridge is ready; document the future `lua src/sim-tools/cli.lua ...` commands inside comments rather than wiring them now.
+
+## Documentation Alignment Tasks
+- Mirror these placeholder expectations in `docs/spec/sim-tools.md` under a dedicated "Current Status" section so spec, plan, and
+  tasks remain in sync.
+- Update `docs/tasks/2025-10-06-sim-tools.md` with checkboxes pointing back to this checklist so executor agents know which
+  scaffolding artifacts to recreate with comment-only pseudo-code.
+
+## Validation Checklist (to execute after scaffolding lands)
+- [ ] Run `./scripts/run-room-server.sh --duration 3` once the CLI bridge is implemented and documented.
+- [ ] Run `./scripts/run-room-client.sh --duration 3` after the client harness placeholder exists, capturing TRACE samples in
+      follow-up task notes.
+- [ ] Record sample TRACE output for both flows in `docs/tasks/2025-10-06-sim-tools.md` to close the loop between code and plan.

--- a/docs/spec/sim-tools.md
+++ b/docs/spec/sim-tools.md
@@ -9,6 +9,11 @@
 ## Overview
 This spec clarifies the behaviour of the simulation tooling workflows so that developers can reliably reproduce and debug matchmaking flows without live players. The active roadmap lives in [docs/plan/2025-10-06-sim-tools.md](../plan/2025-10-06-sim-tools.md) and builds on the earlier checkpoints in [docs/plan/2025-09-30-sim-tools.md](../plan/2025-09-30-sim-tools.md). Guidance captured on the `feature/sim-tools-requirements` branch is folded into this document so the active plan and historical expectations stay in one place.
 
+## Current Status (2025-10-06 validation reset)
+- CLI, harness, and logging scaffolding were temporarily removed while we re-align the placeholder structure with documentation.
+- Follow the reconciliation checklist in [docs/plan/checklists/sim-tools-validation.md](../plan/checklists/sim-tools-validation.md) before re-creating any modules. New files should start as comment-only pseudo-code so future TODOs stay scoped to functions.
+- Wrapper scripts `scripts/run-room-server.sh` / `scripts/run-room-client.sh` remain pending. Use the echo-only stubs in `scripts/sim-tools/` until the CLI bridge is restored through the documented plan.
+
 ## Purpose
 Give developers single-machine room workflow coverage by adding CLI-driven simulators that mirror the in-game `Create Room` (server) and `Join Room` (client) behaviours. Each simulator must reuse existing `src/network` modules to stay in lockstep with runtime logic and emit machine-readable logs for downstream automation.
 

--- a/docs/tasks/2025-10-06-sim-tools.md
+++ b/docs/tasks/2025-10-06-sim-tools.md
@@ -3,6 +3,8 @@
 - branch: feature/sim-tools-requirements
 
 ## Open Work
+- [ ] Recreate placeholder scaffolding per [docs/plan/checklists/sim-tools-validation.md](../plan/checklists/sim-tools-validation.md) (comment-only pseudo-code, no TODOs yet)
+  - Validation: confirm each placeholder references `spec:sim-tools` and links back to the checklist inside its header comment.
 - [ ] Harness implementation: `src/sim-tools/simulation_created_room.lua`, `src/sim-tools/simulation_join_room.lua`
   - Smoke: `./scripts/run-room-server.sh --duration 3 --port 47001 --room-id 3`
   - Smoke: `./scripts/run-room-client.sh --duration 3 --broadcast 255.255.255.255`


### PR DESCRIPTION
## Summary
- remove the premature sim-tools CLI, harness, logging, and test scaffolding so the plan can be realigned before reimplementation
- document the reconciliation checklist and reference it from the spec and active task tracker to keep future work doc-first
- revert the simulation shell entrypoints to simple echo placeholders until the CLI bridge is rebuilt

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db2ead78248324a4bed1c96512c8ab