### PR TITLE
Restructure docs into spec and plan directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@
 - When creating branches from the Codex CLI agent, use the naming pattern `feature/<topic>` to keep automation and reviews consistent.
 
 ## AI Agent Alignment & Traceability
-- Treat every change as agent-executable: note intent before coding in `README.md`, `docs/plan/`, or `docs/spec/` so Qwen 30B Instruct and local runners inherit the same playbook.
+- Treat every change as agent-executable: note intent before coding in `README.md`, `plan/`, or `spec/` so Qwen 30B Instruct and local runners inherit the same playbook.
 - Leave structured breadcrumbs—update test descriptions, commit messages, and inline comments with the feature or spec ID (`spec:<topic>`) so generated traces stay searchable.
-- Sync scenario outlines between `docs/spec/` and the matching `tests/<domain>` files; cross-link the doc in the spec header for quick pivots between design and execution.
+- Sync scenario outlines between `spec/` and the matching `tests/<domain>` files; cross-link the doc in the spec header for quick pivots between design and execution.
 - Keep reusable automation logic in `src/` or `tools/` and expose deterministic entrypoints (`scripts/*.sh`, `tests/support/*.lua`) that agents can invoke without manual tweaking.
 - Prefer hermetic logging over ad-hoc prints. When adding new scripts, emit machine-readable lines (e.g. `TRACE|component|action|status`) to help downstream agents audit execution.
 - When handing off in-progress work to executor agents, capture the active branch, open tasks, and required commands at the top of the relevant doc to maintain continuity.
@@ -17,9 +17,9 @@
 ## Spec-Driven Project Layout
 - Start with executable specs. Mirror directories under `tests/` with their runtime counterparts (`tests/network` ↔ `src/network`) so coverage stays discoverable.
 - Extend `tests/support/` helpers instead of duplicating setup logic in specs; keep fixtures side-effect free and document new helpers with usage notes at the top of the file.
-- Record scenario outlines in `docs/spec/` when behaviour crosses modules, then link those outlines from the related test files and update `docs/tasks/` for any follow-up work.
+- Record scenario outlines in `spec/` when behaviour crosses modules, then link those outlines from the related test files and update `plan/tasks/` for any follow-up work.
 - When adding new root-level code paths, add matching smoke scripts under `scripts/` and mention how to trigger them in `README.md` so remote agents can run verifications end-to-end.
-- Update `docs/plan/` when creating iteration roadmaps and close the loop by referencing the plan in the corresponding specs and commits (`spec:<topic>` tag).
+- Update `plan/` when creating iteration roadmaps and close the loop by referencing the plan in the corresponding specs and commits (`spec:<topic>` tag).
 
 ## Execution Playbook
 - Install LuaRocks + Busted (`luarocks --lua-version=5.1 --lua-interpreter=luajit install busted --local`) before running specs locally or via remote agents.

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ The file `src/network/discovery.lua` sets up a multicast UDP listener and broadc
 
 ### Room simulator workflows (spec:sim-tools)
 
-- Follow `docs/spec/sim-tools.md` for full requirements and logging expectations that keep the simulators aligned with runtime logic.
+- Follow `spec/sim-tools.md` for full requirements and logging expectations that keep the simulators aligned with runtime logic.
 - The server-room harness (to be exposed as `scripts/run-room-server.sh`) bootstraps `RoomServer` with deterministic flags like `--port`, `--room-id`, and `--duration`, then emits machine-readable lines such as `TRACE|sim.server|start|ok|port=47001 roomId=3`.
 - The join-room harness (planned as `scripts/run-room-client.sh`) reuses `Discovery` probes to broadcast, auto-match servers, and report progress via `TRACE|sim.client|discover|sent` / `TRACE|sim.client|join|accept|roomId=...`.
-- Use these simulators to validate create/join flows on a single machine while other devices or agents are offline; capture follow-up tasks in `docs/tasks/2025-09-29-sim-tools.md` when behaviour evolves.
+- Use these simulators to validate create/join flows on a single machine while other devices or agents are offline; capture follow-up tasks in `plan/tasks/2025-09-29-sim-tools.md` when behaviour evolves.
 
 ## Spec-driven architecture
 
 Spec-driven, AI-assited workflow's alignment
-Spec -> baseline requirements, under `docs/spec`
-Plan -> iteration steps for AI/agents, under `docs/plan`
-Tasks -> bite-size actionable units, sometimes auto-generated from plan, under `docs/tasks`
-ADRs -> gauardrails and historical reasoning, under `docs/adrs`
+Spec -> baseline requirements, under `spec`
+Plan -> iteration steps for AI/agents, under `plan`
+Tasks -> bite-size actionable units, sometimes auto-generated from plan, under `plan/tasks`
+ADRs -> gauardrails and historical reasoning, under `docs/ADRs`
 
 - Network code now lives under `src/network`, making it reusable from both runtime scripts and unit specs.
 - `main/main.script` creates a `Discovery` instance, which exposes `listen`, `broadcast_hello`, `receive`, and `close` instance methods.
@@ -48,7 +48,7 @@ ADRs -> gauardrails and historical reasoning, under `docs/adrs`
 
 ### Tests vs specs
 
-- Prefer authoring unit and behaviour specs under `tests/`; `docs/spec/` stores narrative outlines that feed those executables, while integration harnesses can grow alongside them when needed.
+- Prefer authoring unit and behaviour specs under `tests/`; `spec/` stores narrative outlines that feed those executables, while integration harnesses can grow alongside them when needed.
 - Run the full networking spec suite with `./scripts/test-network.sh`, or pass individual files/dirs to `./scripts/test.sh` for focused runs.
 
 ## Development workflow

--- a/docs/ADRs/0001-move-busted-specs-to-tests.md
+++ b/docs/ADRs/0001-move-busted-specs-to-tests.md
@@ -5,15 +5,15 @@
 - Spec ID: spec:tests-suite-location
 
 ## Context
-`docs/spec/` now captures narrative outlines for features and scenarios. Keeping executable Busted suites in `spec/` created friction for tooling and for Qwen 30B hand-offs because the same prefix denoted both documentation and test code. Executors hesitated between `spec/` and `docs/spec/`, and scripts like `./scripts/test.sh` defaulted to the old location.
+`spec/` now captures narrative outlines for features and scenarios. Keeping executable Busted suites in the same tree created friction for tooling and for Qwen 30B hand-offs because the same prefix denoted both documentation and test code. Executors hesitated between implementation specs and documentation, and scripts like `./scripts/test.sh` defaulted to the old location.
 
 ## Decision
 - Relocate every Busted spec helper and suite from `spec/` to `tests/`, mirroring runtime modules (for example, `tests/network` ↔ `src/network`).
 - Rename helper requires to `tests.*` (`tests.spec_helper`, `tests.support.network_context`) so packages resolve without `spec/`.
 - Update harnesses so `./scripts/test.sh` runs `busted tests` by default and `./scripts/test-network.sh` targets `tests/network`.
-- Refresh contributor docs (`README.md`, `AGENTS.md`) to point at the new layout and cross-link to `docs/spec/` for design traces.
+- Refresh contributor docs (`README.md`, `AGENTS.md`) to point at the new layout and cross-link to `spec/` for design traces.
 
 ## Consequences
-- Executors and documenters now have a clear split: `docs/spec/` for intent, `tests/` for runnable specs.
+- Executors and documenters now have a clear split: `spec/` for intent, `tests/` for runnable specs.
 - Existing invocations that referenced `spec/...` must switch to `tests/...`; automation using the old path will fail until updated.
 - Future specs must continue tagging commits, docs, and test files with `spec:<topic>` so traceability survives the relocation.

--- a/docs/QA/README.md
+++ b/docs/QA/README.md
@@ -1,0 +1,3 @@
+# QA Reports
+
+This directory aggregates automated quality summaries such as test results, coverage snapshots, lint reports, and build logs. Add generated artifacts in dated subdirectories or markdown summaries so future agents can trace validation history without combing through console output.

--- a/plan/2025-09-29-agent-session.md
+++ b/plan/2025-09-29-agent-session.md
@@ -4,7 +4,7 @@
 ## Summary
 - Clarified AGENT guidance to align with updated README and Qwen 30B executor workflows.
 - Relocated Busted specs and helpers from `spec/` to `tests/`, updating harness scripts and documentation.
-- Captured the structural shift in `docs/adr/0001-move-busted-specs-to-tests.md` and verified the suite with `./scripts/test.sh`.
+- Captured the structural shift in `docs/ADRs/0001-move-busted-specs-to-tests.md` and verified the suite with `./scripts/test.sh`.
 - Created branch `feature/tests-relocation` for ongoing work.
 
 ## Follow-ups

--- a/plan/2025-09-29-sim-tools.md
+++ b/plan/2025-09-29-sim-tools.md
@@ -20,14 +20,14 @@
 
 ## Tasks
 ### MVP: CLI Join harness wired to Defold Create Room
-1. Update `docs/spec/sim-tools.md` to note the join-first scope and reference the in-game Create Room host as the current S1 coverage point.
+1. Update `spec/sim-tools.md` to note the join-first scope and reference the in-game Create Room host as the current S1 coverage point.
 2. Implement `src/sim-tools/simulation_join_room.lua` with deterministic loops suitable for CLI use, guarded behind `spec:sim-tools` comments.
 3. Expose a shell wrapper `scripts/run-room-client.sh` (and supporting `scripts/sim-tools/simulation-join-room.sh`) that executes the join harness via LuaJIT and relays exit codes.
-4. Document the two-terminal smoke in `docs/tasks/2025-09-29-sim-tools.md`: run the Defold Create Room flow in one terminal, run the join CLI in the other, confirm TRACE logs.
+4. Document the two-terminal smoke in `plan/tasks/2025-09-29-sim-tools.md`: run the Defold Create Room flow in one terminal, run the join CLI in the other, confirm TRACE logs.
 
 ### Follow-up: Standalone CLI Create harness
 5. Implement `src/sim-tools/simulation_created_room.lua` plus supporting harness helpers so a CLI host can stand in for the Defold build.
-6. Add shell wrappers `scripts/run-room-server.sh` / `scripts/sim-tools/simulation-created-room.sh` and expand docs/tasks once the host harness is ready.
+6. Add shell wrappers `scripts/run-room-server.sh` / `scripts/sim-tools/simulation-created-room.sh` and expand task trackers once the host harness is ready.
 7. Extend behaviour specs and logging utilities (`tests/sim-tools/simulation_created_room_spec.lua`, shared logging sinks) after the join MVP lands to keep drift contained.
 
 ## Sub-requirements Breakdown
@@ -42,7 +42,7 @@
   - Provide CLI-facing sinks (stdout/jsonl) that remain fully contained in `src/sim-tools/`.
 - **Runtime ↔ Simulator Isolation**
   - Keep simulator code paths out of `main/` collections and HUD scripts; simulators operate strictly through CLI entrypoints.
-  - Capture terminology guidance inside docs/spec and CLI help text instead of touching runtime UI labels reserved for the shipped experience.
+  - Capture terminology guidance inside `spec/` and CLI help text instead of touching runtime UI labels reserved for the shipped experience.
 - **Test Coverage & Automation Hooks**
   - Expand `tests/sim-tools/` specs to cover client discovery/join flows and CLI duration/exit semantics described under Scenario S2 while queuing server accept loop coverage for the follow-up milestone.
   - Document automation expectations (duration caps, non-zero failures, log assertions) so CI agents can orchestrate self-tests without manual intervention.
@@ -89,9 +89,9 @@
 - `src/sim-tools/ui/` (optional future scope)
   - If lightweight simulator status displays are required later, place them under a new namespace to keep parity with the CLI while avoiding reuse of `main/ui` resources.
 - Documentation touchpoints
-  - Clarify in `docs/spec/sim-tools.md` and README simulator sections that the tooling operates headlessly/CLI-first and does not adjust game UI assets.
+- Clarify in `spec/sim-tools.md` and README simulator sections that the tooling operates headlessly/CLI-first and does not adjust game UI assets.
 - **New artifacts for review**
-  - `docs/tasks/2025-09-29-sim-tools.md` checklist entries to verify no runtime UI files change during simulator work.
+  - `plan/tasks/2025-09-29-sim-tools.md` checklist entries to verify no runtime UI files change during simulator work.
 
 ### Test Coverage & Automation Hooks ↔ Existing Code
 - `tests/sim-tools/simulation_join_room_spec.lua`
@@ -103,10 +103,10 @@
   - `tests/support/sim_tools_fakes.lua` and broader CLI logging specs are tracked for the follow-up milestone to keep the MVP narrowly scoped.
 
 ## Spec / Plan / Task Audit (2025-09-29)
-- **Spec alignment**: `docs/spec/sim-tools.md` now enforces CLI-only isolation for simulators and removes any requirement to rename HUD buttons under `main/ui`. Future edits must preserve the no-UI-touch rule and keep terminology scoped to docs/CLI strings.
+- **Spec alignment**: `spec/sim-tools.md` now enforces CLI-only isolation for simulators and removes any requirement to rename HUD buttons under `main/ui`. Future edits must preserve the no-UI-touch rule and keep terminology scoped to docs/CLI strings.
 - **Plan coverage**: The task list now splits the MVP join harness from the follow-up host work, with two-terminal smoke (Defold host + join CLI) called out explicitly for the first milestone.
-- **Task tracker gaps**: `docs/tasks/2025-09-29-sim-tools.md` should keep the MVP checklist narrowed to the join harness, CLI wrapper, and smoke pair while capturing create-side work in a deferred section.
+- **Task tracker gaps**: `plan/tasks/2025-09-29-sim-tools.md` should keep the MVP checklist narrowed to the join harness, CLI wrapper, and smoke pair while capturing create-side work in a deferred section.
 - **Follow-up**: Once harness modules land, mirror the audit summary into the task tracker notes to keep future agents aware of the isolation guardrails.
 
 ## Coordination
-- Track day-to-day progress in `docs/tasks/2025-09-29-sim-tools.md` (spec:sim-tools).
+- Track day-to-day progress in `plan/tasks/2025-09-29-sim-tools.md` (spec:sim-tools).

--- a/plan/2025-09-30-sim-tools.md
+++ b/plan/2025-09-30-sim-tools.md
@@ -7,17 +7,17 @@ Establish a proof-of-concept workflow for the simulation tooling so developers c
 ## Milestones
 1. **Terminology Alignment**
    - Update `main/ui.gui_script` button labels and `main/main.script` status strings to the new action names.
-   - Refresh `docs/spec/sim-tools.md` so the spec mirrors the renamed flows.
+   - Refresh `spec/sim-tools.md` so the spec mirrors the renamed flows.
 2. **Workflow Validation Harness**
    - Land quick-launch placeholders in `scripts/sim-tools/` for the renamed simulator entry points and describe how they pair with the in-game UI interactions.
    - Instrument lightweight logging around room creation/join events (see `main/main.script`) to surface debugging signals during simulations.
 3. **Proof-of-Concept Sign-off**
-   - Run the three defined validation scenarios and document outcomes, blockers, and follow-up bugs in `docs/tasks/2025-09-30-sim-tools.md`.
-   - Summarize findings and readiness in `docs/spec/sim-tools.md`, updating the validation checklist status.
+   - Run the three defined validation scenarios and document outcomes, blockers, and follow-up bugs in `plan/tasks/2025-09-30-sim-tools.md`.
+   - Summarize findings and readiness in `spec/sim-tools.md`, updating the validation checklist status.
 
 ## Execution Notes
 - Prefer deterministic scripts under `scripts/` that wrap simulator commands so remote agents can run them without manual UI steps.
-- Treat the former `feature/sim-tools-requirements` guidance as merged into this effort—reference `docs/spec/sim-tools.md` for the single source of truth.
+- Treat the former `feature/sim-tools-requirements` guidance as merged into this effort—reference `spec/sim-tools.md` for the single source of truth.
 - Ensure all commits referencing this effort include the `spec:sim-tools` tag for traceability.
 - Coordinate with matchmaking service owners to confirm mock endpoints and room IDs align with production expectations.
 

--- a/plan/checklists/sim-tools-validation.md
+++ b/plan/checklists/sim-tools-validation.md
@@ -19,13 +19,13 @@ and avoid shipping premature implementations.
   CLI bridge is ready; document the future `lua src/sim-tools/cli.lua ...` commands inside comments rather than wiring them now.
 
 ## Documentation Alignment Tasks
-- Mirror these placeholder expectations in `docs/spec/sim-tools.md` under a dedicated "Current Status" section so spec, plan, and
+- Mirror these placeholder expectations in `spec/sim-tools.md` under a dedicated "Current Status" section so spec, plan, and
   tasks remain in sync.
-- Update `docs/tasks/2025-09-29-sim-tools.md` with checkboxes pointing back to this checklist so executor agents know which
+- Update `plan/tasks/2025-09-29-sim-tools.md` with checkboxes pointing back to this checklist so executor agents know which
   scaffolding artifacts to recreate with comment-only pseudo-code.
 
 ## Validation Checklist (to execute after scaffolding lands)
 - [ ] Run `./scripts/run-room-server.sh --duration 3` once the CLI bridge is implemented and documented.
 - [ ] Run `./scripts/run-room-client.sh --duration 3` after the client harness placeholder exists, capturing TRACE samples in
       follow-up task notes.
-- [ ] Record sample TRACE output for both flows in `docs/tasks/2025-09-29-sim-tools.md` to close the loop between code and plan.
+- [ ] Record sample TRACE output for both flows in `plan/tasks/2025-09-29-sim-tools.md` to close the loop between code and plan.

--- a/plan/tasks/2025-09-29-sim-tools.md
+++ b/plan/tasks/2025-09-29-sim-tools.md
@@ -12,7 +12,7 @@
   - Terminal B: `./scripts/run-room-client.sh --duration 3 --broadcast 255.255.255.255`
 
 ## Deferred Follow-up
-- [ ] Recreate placeholder scaffolding per [docs/plan/checklists/sim-tools-validation.md](../plan/checklists/sim-tools-validation.md) (comment-only pseudo-code, no TODOs yet)
+- [ ] Recreate placeholder scaffolding per [plan/checklists/sim-tools-validation.md](../checklists/sim-tools-validation.md) (comment-only pseudo-code, no TODOs yet)
   - Validation: confirm each placeholder references `spec:sim-tools` and links back to the checklist inside its header comment.
 - [ ] Host harness implementation: `src/sim-tools/simulation_created_room.lua`, `src/sim-tools/harness/server.lua`
   - Smoke: `./scripts/run-room-server.sh --duration 3 --port 47001 --room-id 3`
@@ -23,13 +23,13 @@
   - Test: `./scripts/test.sh tests/sim-tools/simulation_cli_spec.lua`
 - [ ] Support modules: `tests/support/sim_tools_fakes.lua`, `src/sim-tools/logging.lua`, `src/sim-tools/log_sinks.lua`
   - Test: `./scripts/test.sh tests/sim-tools`
-- [ ] Documentation sync: update `README.md` Quickstart networking section, refresh `docs/spec/sim-tools.md` pointers, capture audit summary in Notes.
-  - Validation: `rg "spec:sim-tools" docs README.md`
+- [ ] Documentation sync: update `README.md` Quickstart networking section, refresh `spec/sim-tools.md` pointers, capture audit summary in Notes.
+  - Validation: `rg "spec:sim-tools" spec README.md plan`
   - Validation: `rg "Simulation-Created Room" -g"*.md"`
 - [ ] CI hand-off: document `./scripts/run-room-server.sh --duration 3` and `./scripts/run-room-client.sh --duration 3` in automation notes.
-  - Validation: append commands to `docs/plan/checklists/sim-tools-validation.md`
+  - Validation: append commands to `plan/checklists/sim-tools-validation.md`
 
 ## Notes
 - Capture log format updates in this tracker if TRACE schema changes.
-- Revisit `docs/plan/2025-09-29-sim-tools.md` after each milestone to close completed items.
+- Revisit `plan/2025-09-29-sim-tools.md` after each milestone to close completed items.
 - Ensure HUD assets remain untouched; simulators validate solely through the shell commands listed above.

--- a/plan/tasks/2025-09-30-sim-tools.md
+++ b/plan/tasks/2025-09-30-sim-tools.md
@@ -1,24 +1,24 @@
 # Tasks Log 2025-09-30 — spec:sim-tools
 
-Link the execution milestones from [docs/plan/2025-09-30-sim-tools.md](../plan/2025-09-30-sim-tools.md) to discrete tasks so contributors can track completion.
+Link the execution milestones from [plan/2025-09-30-sim-tools.md](../2025-09-30-sim-tools.md) to discrete tasks so contributors can track completion.
 
 The expectations recorded on the historical `feature/sim-tools-requirements` branch are now folded into this checklist; track any follow-up discoveries directly here instead of splitting the backlog across branches.
 
 ## Milestone 1 — Terminology Alignment
 - [ ] `main/ui.gui_script`: rename the Create/Join buttons and related tooltips to **Simulation-Created Room** / **Simulation-Join Room**.
 - [ ] `main/main.script`: update status copy and helper text that reference "Create Room" or "Join Room".
-- [ ] `docs/spec/sim-tools.md`: ensure the spec terminology reflects the renamed simulator flows.
+- [ ] `spec/sim-tools.md`: ensure the spec terminology reflects the renamed simulator flows.
 
 ## Milestone 2 — Workflow Validation Harness
 - [ ] `scripts/sim-tools/simulation-created-room.sh`: implement the quick-launch entry point for the simulated room creation flow.
 - [ ] `scripts/sim-tools/simulation-join-room.sh`: implement the quick-launch entry point for the simulated join flow.
-- [ ] `docs/tasks/2025-09-30-sim-tools.md`: record the multi-process orchestration notes for coordinating the self-test.
+- [ ] `plan/tasks/2025-09-30-sim-tools.md`: record the multi-process orchestration notes for coordinating the self-test.
 - [ ] `main/main.script`: extend lightweight console logging (`TRACE|sim-tools|<action>|<status>`) around room creation/join events.
 
 ## Milestone 3 — Proof-of-Concept Sign-off
-- [x] Execute and record outcomes for the three validation scenarios defined in `docs/spec/sim-tools.md`.
-- [x] Document blockers or bugs discovered during validation, linking to follow-up tasks or tickets in `docs/tasks/`.
-- [ ] Update the validation checklist in [docs/spec/sim-tools.md](../spec/sim-tools.md) with current status.
+- [x] Execute and record outcomes for the three validation scenarios defined in `spec/sim-tools.md`.
+- [x] Document blockers or bugs discovered during validation, linking to follow-up tasks or tickets in `plan/tasks/`.
+- [ ] Update the validation checklist in [spec/sim-tools.md](../spec/sim-tools.md) with current status.
 
 ## Notes
 - 2025-10-02 — spec:sim-tools: Resolved local join failures on macOS by updating `main/main.script` to prefer non-loopback IPs when determining the broadcast subnet.

--- a/spec/sim-tools.md
+++ b/spec/sim-tools.md
@@ -2,18 +2,18 @@
 - Spec ID: spec:sim-tools
 - Status: Draft
 - Owner: Agent session 2025-09-29
-- Linked Plan: docs/plan/2025-09-29-sim-tools.md (active iteration), docs/plan/2025-09-30-sim-tools.md (historical checkpoints)
-- Linked Tasks: docs/tasks/2025-09-29-sim-tools.md, docs/tasks/2025-09-30-sim-tools.md
+- Linked Plan: plan/2025-09-29-sim-tools.md (active iteration), plan/2025-09-30-sim-tools.md (historical checkpoints)
+- Linked Tasks: plan/tasks/2025-09-29-sim-tools.md, plan/tasks/2025-09-30-sim-tools.md
 - Linked Tests: tests/sim-tools/simulation_created_room_spec.lua (S1), tests/sim-tools/simulation_join_room_spec.lua (S2)
 
 ## Overview
-This spec clarifies the behaviour of the simulation tooling workflows so that developers can reliably reproduce and debug matchmaking flows without live players. The active roadmap lives in [docs/plan/2025-09-29-sim-tools.md](../plan/2025-09-29-sim-tools.md) and builds on the earlier checkpoints in [docs/plan/2025-09-30-sim-tools.md](../plan/2025-09-30-sim-tools.md). Guidance captured on the `feature/sim-tools-requirements` branch is folded into this document so the active plan and historical expectations stay in one place.
+This spec clarifies the behaviour of the simulation tooling workflows so that developers can reliably reproduce and debug matchmaking flows without live players. The active roadmap lives in [plan/2025-09-29-sim-tools.md](../plan/2025-09-29-sim-tools.md) and builds on the earlier checkpoints in [plan/2025-09-30-sim-tools.md](../plan/2025-09-30-sim-tools.md). Guidance captured on the `feature/sim-tools-requirements` branch is folded into this document so the active plan and historical expectations stay in one place.
 
 ## Current Status (2025-09-29 validation reset)
 - CLI, harness, and logging scaffolding were temporarily removed while we re-align the placeholder structure with documentation.
 - Scenario S1 (Simulation-Created Room) remains satisfied by running the Defold game build and using the in-game **Create Room** flow; a standalone CLI host will be reintroduced during the follow-up milestone.
 - Scenario S2 (Simulation-Join Room) is the active milestone: rebuild the CLI join harness so it can connect to the in-game host without modifying HUD assets.
-- Follow the reconciliation checklist in [docs/plan/checklists/sim-tools-validation.md](../plan/checklists/sim-tools-validation.md) before re-creating any modules. New files should start as comment-only pseudo-code so future TODOs stay scoped to functions.
+- Follow the reconciliation checklist in [plan/checklists/sim-tools-validation.md](../plan/checklists/sim-tools-validation.md) before re-creating any modules. New files should start as comment-only pseudo-code so future TODOs stay scoped to functions.
 - Wrapper scripts `scripts/run-room-server.sh` / `scripts/run-room-client.sh` remain pending. Use the echo-only stubs in `scripts/sim-tools/` until the CLI bridge is restored through the documented plan.
 
 ## Purpose
@@ -30,7 +30,7 @@ Give developers single-machine room workflow coverage by adding CLI-driven simul
 ## Spec ↔ Code Map
 - **Simulator Harnesses**: `src/sim-tools/simulation_created_room.lua` and `src/sim-tools/simulation_join_room.lua` are the single entry points for automation. Both files tag TODOs with `spec:sim-tools` so follow-up work can reference this spec when wiring CLI flags, TRACE logging, and graceful shutdown logic.
 - **Behaviour Specs**: `tests/sim-tools/simulation_created_room_spec.lua` (Scenario S1) and `tests/sim-tools/simulation_join_room_spec.lua` (Scenario S2) mirror the simulator expectations. Keep describe blocks referencing `spec:sim-tools` for traceability when adding new assertions.
-- **Plans & Tasks**: `docs/plan/2025-09-29-sim-tools.md` and `docs/tasks/2025-09-29-sim-tools.md` must refer to the simulator harness names above to avoid drift between planning notes and executable code.
+- **Plans & Tasks**: `plan/2025-09-29-sim-tools.md` and `plan/tasks/2025-09-29-sim-tools.md` must refer to the simulator harness names above to avoid drift between planning notes and executable code.
 
 ## Requirements
 ### R1: Server-room simulator (spec:sim-tools)
@@ -49,7 +49,7 @@ Give developers single-machine room workflow coverage by adding CLI-driven simul
 ## Terminology & Isolation Updates
 - Keep the shipping HUD labels (**Create Room**, **Join Room**) untouched; simulator naming lives in CLI help text and documentation.
 - Refer to CLI harnesses as **Simulation-Created Room** and **Simulation-Join Room** in docs, scripts, and tests to distinguish them from the HUD flows without altering UI assets.
-- Document any simulator terminology changes inside `docs/spec/` and CLI usage strings instead of modifying `main/ui.gui` resources.
+- Document any simulator terminology changes inside `spec/` and CLI usage strings instead of modifying `main/ui.gui` resources.
 
 ## Proof-of-Concept Scope
 During the initial phase the simulation tools mirror the production Create Room / Join Room flows without requiring real player clients. Simulator entry points operate purely from shell scripts that spawn the harness loops; no simulator work injects messages into HUD scripts or rebinds GUI nodes. The join harness (S2) is the only CLI component being rebuilt immediately—developers should run the Defold **Create Room** flow to satisfy S1 until the follow-up CLI host lands.
@@ -100,7 +100,7 @@ During the initial phase the simulation tools mirror the production Create Room 
 ### Simulation tooling self-test (join-first MVP)
 1. Launch the Defold game build, trigger **Create Room**, and keep the host running in one terminal or window.
 2. Execute `scripts/run-room-client.sh --duration 3 --broadcast 255.255.255.255` from another terminal to run the join harness and observe `TRACE|sim.client|…` logs.
-3. Verify that the join CLI connects successfully, capturing outcomes in `docs/tasks/2025-09-30-sim-tools.md` and `docs/tasks/2025-09-29-sim-tools.md`. The follow-up milestone will expand this smoke to include the standalone CLI host.
+3. Verify that the join CLI connects successfully, capturing outcomes in `plan/tasks/2025-09-30-sim-tools.md` and `plan/tasks/2025-09-29-sim-tools.md`. The follow-up milestone will expand this smoke to include the standalone CLI host.
 
 ## Validation Checklist
 - [ ] Simulator terminology appears in CLI help text and docs only; HUD labels remain unchanged.
@@ -108,4 +108,4 @@ During the initial phase the simulation tools mirror the production Create Room 
 - [ ] Lightweight `TRACE|sim-tools|…` and CLI `TRACE|sim.*|…` console entries are emitted when simulator scripts run their harness loops.
 - [ ] Developers can execute the scenarios above without manual data setup and can rely on the linked task trackers to log outcomes.
 - [ ] Future spec updates synchronise with the listed plan, task, and test documents so executor agents inherit the same expectations.
-- [ ] `src/sim-tools/` harness names and `tests/sim-tools/` spec filenames stay aligned with `docs/plan/2025-09-29-sim-tools.md` and `docs/tasks/2025-09-29-sim-tools.md` references.
+- [ ] `src/sim-tools/` harness names and `tests/sim-tools/` spec filenames stay aligned with `plan/2025-09-29-sim-tools.md` and `plan/tasks/2025-09-29-sim-tools.md` references.

--- a/spec/tests-suite-location.md
+++ b/spec/tests-suite-location.md
@@ -1,16 +1,16 @@
 # Spec: tests suite location
 - Spec ID: spec:tests-suite-location
 - Status: Accepted
-- Linked ADR: docs/adr/0001-move-busted-specs-to-tests.md
+- Linked ADR: docs/ADRs/0001-move-busted-specs-to-tests.md
 - Owner: Agent hand-off log 2025-09-29
 
 ## Purpose
-Ensure all executable Busted suites and helper modules live under `tests/`, leaving `docs/spec/` for narrative outlines. Executor agents should have deterministic entrypoints for running specs and networking smoke tests, and contributor docs must mirror the new layout.
+Ensure all executable Busted suites and helper modules live under `tests/`, leaving `spec/` for narrative outlines. Executor agents should have deterministic entrypoints for running specs and networking smoke tests, and contributor docs must mirror the new layout.
 
 ## Preconditions
 - Repository contains the network discovery and room server modules under `src/network`.
 - Tooling scripts `./scripts/test.sh` and `./scripts/test-network.sh` exist.
-- Documentation directories `README.md`, `AGENTS.md`, and `docs/plan/` are in place.
+- Documentation directories `README.md`, `AGENTS.md`, and `plan/` are in place.
 
 ## Scenarios
 
@@ -31,13 +31,13 @@ Ensure all executable Busted suites and helper modules live under `tests/`, leav
 ### S4: Documentation cross-links trace the layout
 1. `README.md` references behavioural specs residing in `tests/network` and highlights `tests/support` doubles.
 2. `AGENTS.md` mirrors the tests directory guidance and references `tests/support` helpers.
-3. `docs/plan/2025-09-29-agent-session.md` logs the relocation with the `spec:tests-suite-location` tag.
-4. `docs/adr/0001-move-busted-specs-to-tests.md` captures the decision rationale.
+3. `plan/2025-09-29-agent-session.md` logs the relocation with the `spec:tests-suite-location` tag.
+4. `docs/ADRs/0001-move-busted-specs-to-tests.md` captures the decision rationale.
 
 ### S5: Future specs maintain spec:<topic> breadcrumbs
 1. When adding new specs under `tests/`, include the `spec:<topic>` tag in commits, docs, and agent hand-offs.
-2. Scenario outlines for those specs live under `docs/spec/` with the same ID for traceability.
+2. Scenario outlines for those specs live under `spec/` with the same ID for traceability.
 
 ## Verification Notes
 - Ensure ISO date-stamped plan logs exist for each agent session adjusting the suite layout.
-- Remove stale references to `spec/` when new modules or scripts are added; cross-reference this spec during reviews.
+- Remove stale references to the legacy `docs/spec/` path when new modules or scripts are added; cross-reference this spec during reviews.


### PR DESCRIPTION
## Summary
- move planning and spec documentation into new top-level `plan/` and `spec/` trees and refresh README/AGENTS guidance to match
- update specs, plans, tasks, and ADR cross-links so all references use the new locations
- add a QA documentation stub to host future automated validation reports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df57bafaa48324a63a62377b290492