### PR TITLE
Reorganize documentation and agent operating modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,75 @@
 # Agent Guidelines
 
-## Repository Guardrails
-- Hard requirement: this repository does not use Git LFS. Do not commit or push any file that is 100 MB or larger. Run `git ls-files --stage` / `git status --short` and check sizes (e.g. `git ls-files -z | xargs -0 ls -lh`) before committing.
-- If you introduce new generated or binary assets, add them to `.gitignore` instead of versioning them, and ensure existing ignores stay intact.
-- Prefer keeping large build artifacts (editors, SDKs, archives) out of the repo; store them in release storage or re-download on demand.
-- When creating branches from the Codex CLI agent, use the naming pattern `feature/<topic>` to keep automation and reviews consistent.
+> 📌 Start here, then follow the README quick links: [`README.md`](README.md)
 
-## AI Agent Alignment & Traceability
-- Treat every change as agent-executable: note intent before coding in `README.md`, `plan/`, or `spec/` so Qwen 30B Instruct and local runners inherit the same playbook.
-- Leave structured breadcrumbs—update test descriptions, commit messages, and inline comments with the feature or spec ID (`spec:<topic>`) so generated traces stay searchable.
-- Sync scenario outlines between `spec/` and the matching `tests/<domain>` files; cross-link the doc in the spec header for quick pivots between design and execution.
-- Keep reusable automation logic in `src/` or `tools/` and expose deterministic entrypoints (`scripts/*.sh`, `tests/support/*.lua`) that agents can invoke without manual tweaking.
-- Prefer hermetic logging over ad-hoc prints. When adding new scripts, emit machine-readable lines (e.g. `TRACE|component|action|status`) to help downstream agents audit execution.
-- When handing off in-progress work to executor agents, capture the active branch, open tasks, and required commands at the top of the relevant doc to maintain continuity.
+## Collaboration Modes
+
+### Mode A — Interactive (IDE / Roo Code / qwen2.5)
+1. **Propose Plan** – output ≤8 numbered steps, mapping each step to touched files & tests.
+2. **Wait for ACK** – pause until the human replies `ACK step X–Y`.
+3. **Apply** – execute only the acknowledged steps; keep diffs small and leave inline TODOs if follow-up is required.
+4. **Self-check** – run `just check` and share the final one-line summary.
+5. **Summarize** – append findings to the current `plan/sprint-<N>.md` under **Coding Findings**.
+6. **Failure handling** – stop immediately if a command fails, show minimal logs, and recommend a rollback.
+
+### Mode B — Batch (Codex Web UI)
+- Deliver a complete batch with:
+  - **Execution Plan (brief)** – list actions and reasoning.
+  - **Changes** – include the unified diff or explicit file blocks for every edit.
+  - **Tests** – add or update specs with visible diffs.
+  - **Docs** – update `spec/` when behaviour changes, `docs/ADRs/` (Draft/Trial), and `docs/QA/*` summaries when generated.
+  - **Commands** – provide one shell block to reproduce locally (must end with `just check`).
+  - **Rollback** – describe how to revert (files/commands).
+
+Use Mode A when working through an IDE or Roo Code. Use Mode B from web chat or other batch tooling.
+
+## Repository Guardrails
+- This repository does **not** use Git LFS. Never commit files ≥100 MB. Validate with `git ls-files --stage` / `git status --short` and `git ls-files -z | xargs -0 ls -lh` before committing.
+- Keep generated or binary assets out of version control; update `.gitignore` for any new build artefacts.
+- Large tools (editors, SDKs, archives) should stay outside the repo—re-download or document external storage as needed.
+- Branches created by agents should follow `feature/<topic>`.
+
+## Information Architecture
+- **spec/** – authoritative requirements, state machines, and acceptance criteria (WHAT).
+- **plan/** – planning artefacts, roadmaps, sprint scopes, and `plan/TASKS.md` (WHEN/WHO).
+- **src/** & **tests/** – implementation and verification (HOW). Mirror structures for discoverability.
+- **docs/ADRs/** – time-phased MADR-style records explaining major decisions (WHY) ordered chronologically.
+- **docs/principles.md** – evergreen guardrails guiding implementation.
+- Cross-link specs, plans, ADRs, and commits using `spec:<topic>` tags for traceability.
+
+## Practice Tips (Day-to-Day)
+1. **Start from Spec** – confirm relevant requirements in `spec/` before editing code or tests.
+2. **Pick a Task** – select work from `plan/TASKS.md`; each entry links to spec IDs and exit criteria.
+3. **Choose Mode** – IDE → Mode A, web chat → Mode B.
+4. **Check Status** – run `just check` periodically to execute lint/tests/build and refresh `docs/QA/*`.
+5. **Summarize Findings** – append 3–5 bullets to `plan/sprint-<N>.md` under **Coding Findings**.
+6. **Decisions** – draft ADRs as **Draft/Trial**; only mark **Accepted** after a recorded `DECISION: ACCEPT <ADR-ID>`.
+7. **Push Policy** – use forks for remote operations; keep instructions agent-executable.
 
 ## Spec-Driven Project Layout
-- Start with executable specs. Mirror directories under `tests/` with their runtime counterparts (`tests/network` ↔ `src/network`) so coverage stays discoverable.
-- Extend `tests/support/` helpers instead of duplicating setup logic in specs; keep fixtures side-effect free and document new helpers with usage notes at the top of the file.
-- Record scenario outlines in `spec/` when behaviour crosses modules, then link those outlines from the related test files and update `plan/tasks/` for any follow-up work.
-- When adding new root-level code paths, add matching smoke scripts under `scripts/` and mention how to trigger them in `README.md` so remote agents can run verifications end-to-end.
-- Update `plan/` when creating iteration roadmaps and close the loop by referencing the plan in the corresponding specs and commits (`spec:<topic>` tag).
+- Maintain executable specs that mirror runtime modules (`tests/network` ↔ `src/network`).
+- Extend helpers under `tests/support/` instead of duplicating setup logic; keep fixtures side-effect free and document usage at the top of each helper.
+- Record cross-module behaviour in `spec/` and link related tests plus tasks in `plan/`.
+- When adding new root-level entry points, pair them with smoke scripts under `scripts/` and document invocation in `README.md`.
+- Update plans when creating iteration roadmaps; reference the plan and spec IDs in commits via `spec:<topic>`.
 
 ## Execution Playbook
-- Install LuaRocks + Busted (`luarocks --lua-version=5.1 --lua-interpreter=luajit install busted --local`) before running specs locally or via remote agents.
-- Run the full spec suite with `./scripts/test.sh`; use `./scripts/test-network.sh` for focused networking checks and pass explicit spec paths for tight loops.
-- Build artifacts with `./scripts/build.sh` (Bob wrapper) and use `./scripts/bob-smoke.sh` to exercise Bob's `resolve`, `build`, and `bundle` commands in sequence.
-- Override network ports per environment through `[network] discovery_port` in `game.project` when orchestrating multi-agent or multi-device test runs.
+- Install LuaRocks + Busted (`luarocks --lua-version=5.1 --lua-interpreter=luajit install busted --local`) before running specs.
+- Run the full suite with `./scripts/test.sh`; use `./scripts/test-network.sh` for network-focused checks.
+- Build via `./scripts/build.sh` (Bob wrapper) and smoke Bob with `./scripts/bob-smoke.sh` (resolve → build → bundle).
+- Configure discovery ports per environment through `[network] discovery_port` in `game.project` when orchestrating multi-agent tests.
 
 ## GitHub Workflows
-- The repository intentionally ships without GitHub Actions; do not create or restore `.github/workflows/*.yml` files unless the owner provides explicit instructions.
-- If a task mentions CI, confirm with the owner whether workflows should remain absent before touching GitHub configuration.
-- Document any local validation steps in `README.md`, specs, or task trackers instead of relying on hosted workflows.
+- The repository intentionally excludes GitHub Actions—do not add `.github/workflows/*.yml` without explicit owner approval.
+- If CI is required, confirm expectations with the owner before modifying workflow configuration.
+- Document local validation steps in `README.md`, `spec/`, or `plan/` instead of relying on hosted workflows.
 
 ## Defold 1.11 Quick-Test Playbook
-- When wiring new GUI components into a collection, use literal component ids (e.g. `/main/ui.gui`) and avoid escaped quotes or Defold will reject the collection.
-- Stick to `/builtins/fonts/default.font` for UI text; older Defold runtimes ship without `system_font.font`.
-- Post messages with fully qualified URLs such as `main:/go#ui` ↔ `main:/go#main` to avoid "socket ''" errors when components initialize.
-- Give the GUI input focus (and drop it from the script) so buttons receive touch events; mixing both can swallow clicks.
-- In Defold 1.11 `gui.pick_node` expects scalar `x, y` arguments—wrap touches with `vmath.vector3` only if you pass the individual components.
-- Avoid `gui.set_text_align`—it was added after 1.11. Use pivots and padding instead when formatting text nodes.
-- When adding UDP ping/pong utilities, bind the server to a fixed port, compute a subnet broadcast from `socket.dns.toip` (fall back to `255.255.255.255`), and log each send/receive so multi-machine tests can be verified quickly.
-- Keep ad-hoc capture folders like `screencaps/` out of version control by updating `.gitignore`.
+- Use literal component IDs (e.g. `/main/ui.gui`) when wiring GUI components into collections.
+- Prefer `/builtins/fonts/default.font` for UI text; older runtimes omit `system_font.font`.
+- Post messages with fully qualified URLs (e.g. `main:/go#ui`) to avoid empty-socket errors during component init.
+- Ensure the GUI holds input focus so buttons receive touch events; release focus from scripts to prevent swallowed clicks.
+- `gui.pick_node` expects scalar `x, y` arguments in Defold 1.11—wrap touches with `vmath.vector3` only when passing components individually.
+- Avoid `gui.set_text_align` (added after 1.11); rely on pivots and padding for formatting.
+- For UDP ping/pong utilities, bind servers to fixed ports, compute subnet broadcasts from `socket.dns.toip` (fallback `255.255.255.255`), and log each send/receive.
+- Keep temporary capture folders like `screencaps/` out of version control via `.gitignore` updates.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Welcome to Defold
 
+## Quick Links
+- [Agent Operating Modes](AGENTS.md)
+- [Authoritative Specs (`spec/`)](spec)
+- [Active Tasks (`plan/TASKS.md`)](plan/TASKS.md)
+- [Design Decisions (`docs/ADRs/`)](docs/ADRs)
+- [Evergreen Principles](docs/principles.md)
+
 This project was created from the "mobile" project template. This means that the settings in ["game.project"](defold://open?path=/game.project) have been changed to be suitable for a mobile game:
 
 - The screen size is set to 640x1136

--- a/docs/ADRs/0001-move-busted-specs-to-tests.md
+++ b/docs/ADRs/0001-move-busted-specs-to-tests.md
@@ -1,19 +1,41 @@
 # ADR 0001: Move Busted specs to tests directory
 
 - Status: Accepted
+- Deciders: Core maintainers
 - Date: 2025-09-29
-- Spec ID: spec:tests-suite-location
+- Tags: spec:tests-suite-location
 
-## Context
-`spec/` now captures narrative outlines for features and scenarios. Keeping executable Busted suites in the same tree created friction for tooling and for Qwen 30B hand-offs because the same prefix denoted both documentation and test code. Executors hesitated between implementation specs and documentation, and scripts like `./scripts/test.sh` defaulted to the old location.
+## Status History
+| Phase | Date | Notes |
+| --- | --- | --- |
+| Draft | 2025-09-28 | Documented tooling friction caused by mixed spec + test hierarchy. |
+| Trial | 2025-09-29 | Ran `./scripts/test.sh` from relocated tree to validate harness updates. |
+| Accepted | 2025-09-29 | `DECISION: ACCEPT ADR-0001` recorded after confirming team-wide alignment. |
 
-## Decision
-- Relocate every Busted spec helper and suite from `spec/` to `tests/`, mirroring runtime modules (for example, `tests/network` ↔ `src/network`).
-- Rename helper requires to `tests.*` (`tests.spec_helper`, `tests.support.network_context`) so packages resolve without `spec/`.
-- Update harnesses so `./scripts/test.sh` runs `busted tests` by default and `./scripts/test-network.sh` targets `tests/network`.
-- Refresh contributor docs (`README.md`, `AGENTS.md`) to point at the new layout and cross-link to `spec/` for design traces.
+## Context and Problem Statement
+`spec/` now captures narrative outlines for features and scenarios. Housing executable Busted suites in the same tree confused both humans and automation: identical prefixes hid whether a file was documentation or runnable code, and helpers such as `tests/support/network_context.lua` were difficult to discover. Scripts like `./scripts/test.sh` defaulted to the legacy path, leading to drift between spec intent and verification.
 
-## Consequences
-- Executors and documenters now have a clear split: `spec/` for intent, `tests/` for runnable specs.
-- Existing invocations that referenced `spec/...` must switch to `tests/...`; automation using the old path will fail until updated.
-- Future specs must continue tagging commits, docs, and test files with `spec:<topic>` so traceability survives the relocation.
+## Decision Drivers
+1. Preserve a single source of truth for requirements under `spec/`.
+2. Improve discoverability by mirroring runtime modules (`tests/network` ↔ `src/network`).
+3. Keep automation entry points stable for agents and CI scripts.
+
+## Considered Options
+1. **Maintain mixed tree** – no relocation; continue documenting the split manually. Rejected due to persistent confusion.
+2. **Introduce subfolders under `spec/`** – place executable specs in `spec/tests/`. Rejected because it still couples documentation and code.
+3. **Relocate tests to top-level `tests/`** – mirror runtime layout and retarget harnesses. Chosen option.
+
+## Decision Outcome
+- Move every Busted helper and suite from `spec/` to `tests/`, matching runtime namespaces.
+- Update `require` paths to `tests.*` (for example, `tests.spec_helper`, `tests.support.network_context`).
+- Update harnesses so `./scripts/test.sh` executes `busted tests` and `./scripts/test-network.sh` targets `tests/network` by default.
+- Refresh contributor docs (`README.md`, `AGENTS.md`) to explain the new split and cross-link specs for intent.
+
+## Consequences and Follow-up
+- Executors and documenters now have a clear contract: `spec/` = intent, `tests/` = verification.
+- Any automation that referenced `spec/...` must update paths or will fail. Track outstanding updates in `plan/TASKS.md`.
+- Continue tagging commits, docs, and test files with `spec:<topic>` to keep traceability across the reorganised tree.
+
+## References
+- [`spec/tests-suite-location.md`](../../spec/tests-suite-location.md) – authoritative requirements for the suite layout.
+- [`README.md`](../../README.md) – onboarding notes and execution commands for the relocated tests.

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,0 +1,31 @@
+# Engineering Principles
+
+These evergreen guardrails steer implementation choices, regardless of sprint-specific context.
+
+## 1. Spec-First Delivery
+- Treat `spec/` as the source of truth for behaviour. New work begins by refining the relevant spec and linking it to commits and tasks (`spec:<topic>` tags).
+- Keep specs executable by mirroring the runtime structure under `tests/` and ensuring every scenario in `spec/` maps to at least one automated check.
+
+## 2. Traceable Planning
+- Maintain task intent in `plan/TASKS.md`, linking each item to the owning spec and validation commands.
+- Reference planning artefacts from commits, docs, and ADRs to ensure future agents can trace decisions end-to-end.
+
+## 3. Deterministic Tooling
+- Prefer hermetic scripts under `scripts/` with machine-readable logs (`TRACE|component|action|status`) so local and remote agents share the same execution surface.
+- Document required environment setup in `README.md` and keep command entry points stable.
+
+## 4. Modular Runtime & Tests
+- Structure production code and tests with shared abstractions (`tests/support/`) to avoid duplication and ease simulator validation.
+- Keep fixtures side-effect free; inject dependencies so unit and simulator flows can run in isolation.
+
+## 5. Decision Hygiene
+- Record impactful choices as time-phased MADR entries in `docs/ADRs/`. Promote entries from Draft → Trial → Accepted only after stakeholders log `DECISION: ACCEPT <ADR-ID>`.
+- Capture follow-up questions or open issues inside the ADR "Consequences" section to guide future updates.
+
+## 6. Network Transparency
+- Log network discovery, broadcasting, and join events with explicit payloads to aid debugging across devices.
+- Default to safe fallbacks (e.g. broadcast `255.255.255.255`) while allowing overrides via `game.project` configuration.
+
+## 7. Asset Discipline
+- Avoid versioning large binaries; document acquisition steps instead.
+- Update `.gitignore` whenever new generated artefacts appear in local workflows.

--- a/plan/TASKS.md
+++ b/plan/TASKS.md
@@ -1,0 +1,16 @@
+# Active Tasks
+
+This backlog links day-to-day execution to the authoritative specs.
+
+| ID | Spec | Summary | Owner/Mode | Validation |
+| --- | --- | --- | --- | --- |
+| T-2025-09-29-A | spec:sim-tools | Rebuild join harness (`src/sim-tools/simulation_join_room.lua`, `src/sim-tools/harness/client.lua`) and CLI wrappers. See [plan/tasks/2025-09-29-sim-tools.md](tasks/2025-09-29-sim-tools.md). | Mode A/B | `./scripts/test.sh tests/sim-tools/simulation_join_room_spec.lua` |
+| T-2025-09-29-B | spec:sim-tools | Implement host harness + CLI surfaces; capture log schema updates. Track in [plan/tasks/2025-09-29-sim-tools.md](tasks/2025-09-29-sim-tools.md). | Mode B | `./scripts/test.sh tests/sim-tools` |
+| T-2025-09-30-A | spec:sim-tools | Align UI terminology and spec language with simulator naming. See [plan/tasks/2025-09-30-sim-tools.md](tasks/2025-09-30-sim-tools.md). | Mode A | Manual UI check + spec diff |
+| T-2025-09-30-B | spec:sim-tools | Ship simulator workflow scripts and orchestration notes. See [plan/tasks/2025-09-30-sim-tools.md](tasks/2025-09-30-sim-tools.md). | Mode B | `./scripts/sim-tools/simulation-*.sh --help` + trace review |
+| T-2025-09-30-C | spec:sim-tools | Refresh validation checklist and record recent runs. See [plan/tasks/2025-09-30-sim-tools.md](tasks/2025-09-30-sim-tools.md). | Mode A | `./scripts/test.sh tests/sim-tools/simulation_created_room_spec.lua` |
+
+## Usage
+1. Pick a task row, confirm the linked spec entry, and decide on Mode A or Mode B.
+2. Update the underlying task file with progress notes, validation output, and follow-up TODOs.
+3. When complete, cross-reference the closing commit or ADR in the task file and add a note under `plan/sprint-<N>.md`.


### PR DESCRIPTION
## Summary
- document interactive vs batch collaboration modes and clarify repository information architecture in AGENTS.md
- add docs/principles.md and plan/TASKS.md to anchor evergreen guardrails and day-to-day backlog links
- refresh ADR-0001 to MADR time-phased format and add README quick links to the new docs

## Testing
- not run (documentation-only)


------
https://chatgpt.com/codex/tasks/task_e_68df633a5f8483248d13870b7eeca150